### PR TITLE
Fix spawn calls for windows

### DIFF
--- a/src/buildLibrary.ts
+++ b/src/buildLibrary.ts
@@ -43,7 +43,7 @@ export function buildLibrary({
       }
 
       // Build types
-      const ts = spawn(`tsc`, [`--project`, tsconfig, `--outDir`, outdir])
+      const ts = spawn(`tsc`, [`--project`, tsconfig, `--outDir`, outdir], { shell: true })
 
       ts.stdout.on('data', function (data: any) {
         const str = data.toString()
@@ -64,7 +64,7 @@ export function buildLibrary({
           }
         }
         if (cfgWithPaths) {
-          const trp = spawn(`tsconfig-replace-paths`, [`-p`, cfgWithPaths])
+          const trp = spawn(`tsconfig-replace-paths`, [`-p`, cfgWithPaths], { shell: true })
           trp.on('exit', () => {
             log(`✔ ${name}: Resolved paths`)
             finish(true)

--- a/src/devLibrary.ts
+++ b/src/devLibrary.ts
@@ -28,7 +28,9 @@ export async function devLibrary({
 
   log(`‣ ${name}: Starting watch mode`)
 
-  const ts = spawn(`tsc`, [`-w`, `--project`, tsconfig, `--pretty`, `--preserveWatchOutput`])
+  const ts = spawn(`tsc`, [`-w`, `--project`, tsconfig, `--pretty`, `--preserveWatchOutput`], {
+    shell: true,
+  })
 
   const errRegex = /error(.*)TS/g
   const cleanRegex = /Found 0 errors\./g


### PR DESCRIPTION
Add `{shell: true}` to the 3rd optons argument to `spawn`